### PR TITLE
Revert "fix: bump macos pdfium to 3961"

### DIFF
--- a/macosxprecompiled/libpdfium.a
+++ b/macosxprecompiled/libpdfium.a
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa34ccf1a4d295d5d7e67bd4b24b57b34bbedc00e316dd4af64eb8d959b100d3
-size 12473256
+oid sha256:c68cd39fdcc3acc121de6ded4a60fdc4291ed03989d9ab2eb9a2a0e0a06db5d0
+size 10898848


### PR DESCRIPTION
This reverts commit c25ecd7c5bf1f94bd9b59ecba9f91fe91ab3a42f.
The new binary makes the epub export test hang, which means something is
wrong with the update. Let's move everything else forward, then we can
attempt to push macos forward again.